### PR TITLE
Support tag updates for `Activity` resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-07-22T20:35:39Z"
+  build_date: "2022-08-11T00:55:59Z"
   build_hash: 87477ae8ca8ac6ddb8c565bbd910cc7e30f55ed0
-  go_version: go1.17.5
+  go_version: go1.18.1
   version: v0.19.3
 api_directory_checksum: fb0d67de142257cc8f80703c3f14eabbd87711b7
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 779cd51aebe9b88e47ee15f334cf80a5aa547d92
+  file_checksum: acf47eb68cd1d37f15d79905899c2247dfd4a4f8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -9,4 +9,17 @@ resources:
       errors:
         404:
           code: ActivityDoesNotExist
+    fields:
+      Name:
+        is_immutable: true
+      Tags:
+        compare:
+          is_ignored: True
+    hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
+      sdk_read_one_post_set_output:
+        template_path: hooks/activity/sdk_read_one_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateActivity
 model_name: states

--- a/generator.yaml
+++ b/generator.yaml
@@ -9,4 +9,17 @@ resources:
       errors:
         404:
           code: ActivityDoesNotExist
+    fields:
+      Name:
+        is_immutable: true
+      Tags:
+        compare:
+          is_ignored: True
+    hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
+      sdk_read_one_post_set_output:
+        template_path: hooks/activity/sdk_read_one_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateActivity
 model_name: states

--- a/pkg/resource/activity/delta.go
+++ b/pkg/resource/activity/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
@@ -47,9 +48,6 @@ func newResourceDelta(
 		if *a.ko.Spec.Name != *b.ko.Spec.Name {
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
-	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/activity/hooks.go
+++ b/pkg/resource/activity/hooks.go
@@ -1,0 +1,197 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package activity
+
+import (
+	"context"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
+	svcsdk "github.com/aws/aws-sdk-go/service/sfn"
+
+	svcapitypes "github.com/aws-controllers-k8s/sfn-controller/apis/v1alpha1"
+)
+
+// setResourceAdditionalFields queries and adds the tags to an Activity resource
+func (rm *resourceManager) setResourceAdditionalFields(
+	ctx context.Context,
+	ko *svcapitypes.Activity,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setResourceAdditionalFields")
+	defer exit(err)
+
+	// Set activity tags
+	ko.Spec.Tags, err = rm.getActivityTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// getActivityTags retrieves a resource list of tags.
+func (rm *resourceManager) getActivityTags(ctx context.Context, resourceARN string) ([]*svcapitypes.Tag, error) {
+	listTagsForResourceResponse, err := rm.sdkapi.ListTagsForResourceWithContext(
+		ctx,
+		&svcsdk.ListTagsForResourceInput{
+			ResourceArn: &resourceARN,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "ListTagsForResource", err)
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]*svcapitypes.Tag, 0, len(listTagsForResourceResponse.Tags))
+	for _, tag := range listTagsForResourceResponse.Tags {
+		tags = append(tags, &svcapitypes.Tag{
+			Key:   tag.Key,
+			Value: tag.Value,
+		})
+	}
+	return tags, nil
+}
+
+// customUpdateActivity patches each of the resource properties in the backend AWS
+// service API and returns a new resource with updated fields.
+func (rm *resourceManager) customUpdateActivity(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (*resource, error) {
+	if delta.DifferentAt("Spec.Tags") {
+		err := rm.updateActivityTags(ctx, latest, desired)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return desired, nil
+}
+
+// updateActivityTags uses TagResource and UntagResource to add, remove and update
+// activitytags.
+func (rm *resourceManager) updateActivityTags(
+	ctx context.Context,
+	latest *resource,
+	desired *resource,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.updateRuleGroupsTags")
+	defer exit(err)
+
+	addedOrUpdated, removed := computeTagsDelta(latest.ko.Spec.Tags, desired.ko.Spec.Tags)
+
+	if len(removed) > 0 {
+		_, err = rm.sdkapi.UntagResourceWithContext(
+			ctx,
+			&svcsdk.UntagResourceInput{
+				ResourceArn: (*string)(latest.ko.Status.ACKResourceMetadata.ARN),
+				TagKeys:     removed,
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "UntagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(addedOrUpdated) > 0 {
+		_, err = rm.sdkapi.TagResourceWithContext(
+			ctx,
+			&svcsdk.TagResourceInput{
+				ResourceArn: (*string)(latest.ko.Status.ACKResourceMetadata.ARN),
+				Tags:        sdkTagsFromResourceTags(addedOrUpdated),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "TagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		if !equalTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
+// equalTags returns true if two Tag arrays are equal regardless of the order
+// of their elements.
+func equalTags(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) bool {
+	addedOrUpdated, removed := computeTagsDelta(a, b)
+	return len(addedOrUpdated) == 0 && len(removed) == 0
+}
+
+// computeTagsDelta compares two Tag arrays and return two different list
+// containing the addedOrupdated and removed tags.
+// The removed tags only contains the Key of tags
+func computeTagsDelta(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
+	var visitedIndexes []string
+mainLoop:
+	for _, aElement := range a {
+		visitedIndexes = append(visitedIndexes, *aElement.Key)
+		for _, bElement := range b {
+			if equalStrings(aElement.Key, bElement.Key) {
+				if !equalStrings(aElement.Value, bElement.Value) {
+					addedOrUpdated = append(addedOrUpdated, bElement)
+				}
+				continue mainLoop
+			}
+		}
+		removed = append(removed, aElement.Key)
+	}
+	for _, bElement := range b {
+		if !ackutil.InStrings(*bElement.Key, visitedIndexes) {
+			addedOrUpdated = append(addedOrUpdated, bElement)
+		}
+	}
+	return addedOrUpdated, removed
+}
+
+// svcTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag array.
+func sdkTagsFromResourceTags(rTags []*svcapitypes.Tag) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = &svcsdk.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
+}

--- a/pkg/resource/activity/hooks.go
+++ b/pkg/resource/activity/hooks.go
@@ -18,10 +18,9 @@ import (
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
-	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
-	svcsdk "github.com/aws/aws-sdk-go/service/sfn"
 
 	svcapitypes "github.com/aws-controllers-k8s/sfn-controller/apis/v1alpha1"
+	commonutil "github.com/aws-controllers-k8s/sfn-controller/pkg/util"
 )
 
 // setResourceAdditionalFields queries and adds the tags to an Activity resource
@@ -31,37 +30,21 @@ func (rm *resourceManager) setResourceAdditionalFields(
 ) (err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.setResourceAdditionalFields")
-	defer exit(err)
+	defer func() {
+		exit(err)
+	}()
 
 	// Set activity tags
-	ko.Spec.Tags, err = rm.getActivityTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))
+	ko.Spec.Tags, err = commonutil.GetResourceTags(
+		ctx,
+		rm.sdkapi,
+		rm.metrics,
+		string(*ko.Status.ACKResourceMetadata.ARN),
+	)
 	if err != nil {
 		return err
 	}
-
 	return nil
-}
-
-// getActivityTags retrieves a resource list of tags.
-func (rm *resourceManager) getActivityTags(ctx context.Context, resourceARN string) ([]*svcapitypes.Tag, error) {
-	listTagsForResourceResponse, err := rm.sdkapi.ListTagsForResourceWithContext(
-		ctx,
-		&svcsdk.ListTagsForResourceInput{
-			ResourceArn: &resourceARN,
-		},
-	)
-	rm.metrics.RecordAPICall("GET", "ListTagsForResource", err)
-	if err != nil {
-		return nil, err
-	}
-	tags := make([]*svcapitypes.Tag, 0, len(listTagsForResourceResponse.Tags))
-	for _, tag := range listTagsForResourceResponse.Tags {
-		tags = append(tags, &svcapitypes.Tag{
-			Key:   tag.Key,
-			Value: tag.Value,
-		})
-	}
-	return tags, nil
 }
 
 // customUpdateActivity patches each of the resource properties in the backend AWS
@@ -73,7 +56,14 @@ func (rm *resourceManager) customUpdateActivity(
 	delta *ackcompare.Delta,
 ) (*resource, error) {
 	if delta.DifferentAt("Spec.Tags") {
-		err := rm.updateActivityTags(ctx, latest, desired)
+		err := commonutil.SyncResourceTags(
+			ctx,
+			rm.sdkapi,
+			rm.metrics,
+			string(*desired.ko.Status.ACKResourceMetadata.ARN),
+			latest.ko.Spec.Tags,
+			desired.ko.Spec.Tags,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -81,49 +71,6 @@ func (rm *resourceManager) customUpdateActivity(
 	return desired, nil
 }
 
-// updateActivityTags uses TagResource and UntagResource to add, remove and update
-// activitytags.
-func (rm *resourceManager) updateActivityTags(
-	ctx context.Context,
-	latest *resource,
-	desired *resource,
-) error {
-	var err error
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.updateRuleGroupsTags")
-	defer exit(err)
-
-	addedOrUpdated, removed := computeTagsDelta(latest.ko.Spec.Tags, desired.ko.Spec.Tags)
-
-	if len(removed) > 0 {
-		_, err = rm.sdkapi.UntagResourceWithContext(
-			ctx,
-			&svcsdk.UntagResourceInput{
-				ResourceArn: (*string)(latest.ko.Status.ACKResourceMetadata.ARN),
-				TagKeys:     removed,
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "UntagResource", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	if len(addedOrUpdated) > 0 {
-		_, err = rm.sdkapi.TagResourceWithContext(
-			ctx,
-			&svcsdk.TagResourceInput{
-				ResourceArn: (*string)(latest.ko.Status.ACKResourceMetadata.ARN),
-				Tags:        sdkTagsFromResourceTags(addedOrUpdated),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "TagResource", err)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
 func customPreCompare(
 	delta *ackcompare.Delta,
 	a *resource,
@@ -132,66 +79,8 @@ func customPreCompare(
 	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	} else if len(a.ko.Spec.Tags) > 0 {
-		if !equalTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		if !commonutil.EqualTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 		}
 	}
-}
-
-// equalTags returns true if two Tag arrays are equal regardless of the order
-// of their elements.
-func equalTags(
-	a []*svcapitypes.Tag,
-	b []*svcapitypes.Tag,
-) bool {
-	addedOrUpdated, removed := computeTagsDelta(a, b)
-	return len(addedOrUpdated) == 0 && len(removed) == 0
-}
-
-// computeTagsDelta compares two Tag arrays and return two different list
-// containing the addedOrupdated and removed tags.
-// The removed tags only contains the Key of tags
-func computeTagsDelta(
-	a []*svcapitypes.Tag,
-	b []*svcapitypes.Tag,
-) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
-	var visitedIndexes []string
-mainLoop:
-	for _, aElement := range a {
-		visitedIndexes = append(visitedIndexes, *aElement.Key)
-		for _, bElement := range b {
-			if equalStrings(aElement.Key, bElement.Key) {
-				if !equalStrings(aElement.Value, bElement.Value) {
-					addedOrUpdated = append(addedOrUpdated, bElement)
-				}
-				continue mainLoop
-			}
-		}
-		removed = append(removed, aElement.Key)
-	}
-	for _, bElement := range b {
-		if !ackutil.InStrings(*bElement.Key, visitedIndexes) {
-			addedOrUpdated = append(addedOrUpdated, bElement)
-		}
-	}
-	return addedOrUpdated, removed
-}
-
-// svcTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag array.
-func sdkTagsFromResourceTags(rTags []*svcapitypes.Tag) []*svcsdk.Tag {
-	tags := make([]*svcsdk.Tag, len(rTags))
-	for i := range rTags {
-		tags[i] = &svcsdk.Tag{
-			Key:   rTags[i].Key,
-			Value: rTags[i].Value,
-		}
-	}
-	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil || *b == ""
-	}
-	return (*a == "" && b == nil) || *a == *b
 }

--- a/pkg/resource/activity/sdk.go
+++ b/pkg/resource/activity/sdk.go
@@ -106,6 +106,9 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
+		return nil, err
+	}
 	return &resource{ko}, nil
 }
 
@@ -215,8 +218,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, ackerr.NotImplemented
+	return rm.customUpdateActivity(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API
@@ -355,4 +357,16 @@ func (rm *resourceManager) updateConditions(
 func (rm *resourceManager) terminalAWSError(err error) bool {
 	// No terminal_errors specified for this resource in generator config
 	return false
+}
+
+// getImmutableFieldChanges returns list of immutable fields from the
+func (rm *resourceManager) getImmutableFieldChanges(
+	delta *ackcompare.Delta,
+) []string {
+	var fields []string
+	if delta.DifferentAt("Spec.Name") {
+		fields = append(fields, "Name")
+	}
+
+	return fields
 }

--- a/pkg/util/tags.go
+++ b/pkg/util/tags.go
@@ -1,0 +1,174 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import (
+	"context"
+
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	svcsdk "github.com/aws/aws-sdk-go/service/sfn"
+
+	svcapitypes "github.com/aws-controllers-k8s/sfn-controller/apis/v1alpha1"
+)
+
+// TODO(a-hilaly) most of the utility in this package should ideally go to
+// ack runtime repository.
+
+type metricsRecorder interface {
+	RecordAPICall(opType string, opID string, err error)
+}
+
+//
+type tagsClient interface {
+	TagResourceWithContext(context.Context, *svcsdk.TagResourceInput, ...request.Option) (*svcsdk.TagResourceOutput, error)
+	ListTagsForResourceWithContext(context.Context, *svcsdk.ListTagsForResourceInput, ...request.Option) (*svcsdk.ListTagsForResourceOutput, error)
+	UntagResourceWithContext(context.Context, *svcsdk.UntagResourceInput, ...request.Option) (*svcsdk.UntagResourceOutput, error)
+}
+
+// GetResourceTags retrieves a resource list of tags.
+func GetResourceTags(
+	ctx context.Context,
+	client tagsClient,
+	mr metricsRecorder,
+	resourceARN string,
+) ([]*svcapitypes.Tag, error) {
+	listTagsForResourceResponse, err := client.ListTagsForResourceWithContext(
+		ctx,
+		&svcsdk.ListTagsForResourceInput{
+			ResourceArn: &resourceARN,
+		},
+	)
+	mr.RecordAPICall("GET", "ListTagsForResource", err)
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]*svcapitypes.Tag, 0, len(listTagsForResourceResponse.Tags))
+	for _, tag := range listTagsForResourceResponse.Tags {
+		tags = append(tags, &svcapitypes.Tag{
+			Key:   tag.Key,
+			Value: tag.Value,
+		})
+	}
+	return tags, nil
+}
+
+// SyncResourceTags uses TagResource and UntagResource API Calls to add, remove
+// and update resource tags.
+func SyncResourceTags(
+	ctx context.Context,
+	client tagsClient,
+	mr metricsRecorder,
+	resourceARN string,
+	latestTags []*svcapitypes.Tag,
+	desiredTags []*svcapitypes.Tag,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("common.SyncResourceTags")
+	defer func() {
+		exit(err)
+	}()
+
+	addedOrUpdated, removed := computeTagsDelta(latestTags, desiredTags)
+
+	if len(removed) > 0 {
+		_, err = client.UntagResourceWithContext(
+			ctx,
+			&svcsdk.UntagResourceInput{
+				ResourceArn: aws.String(resourceARN),
+				TagKeys:     removed,
+			},
+		)
+		mr.RecordAPICall("UPDATE", "UntagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(addedOrUpdated) > 0 {
+		_, err = client.TagResourceWithContext(
+			ctx,
+			&svcsdk.TagResourceInput{
+				ResourceArn: aws.String(resourceARN),
+				Tags:        sdkTagsFromResourceTags(addedOrUpdated),
+			},
+		)
+		mr.RecordAPICall("UPDATE", "TagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// computeTagsDelta compares two Tag arrays and return two different list
+// containing the addedOrupdated and removed tags. The removed tags array
+// only contains the tags Keys.
+func computeTagsDelta(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
+	var visitedIndexes []string
+mainLoop:
+	for _, aElement := range a {
+		visitedIndexes = append(visitedIndexes, *aElement.Key)
+		for _, bElement := range b {
+			if equalStrings(aElement.Key, bElement.Key) {
+				if !equalStrings(aElement.Value, bElement.Value) {
+					addedOrUpdated = append(addedOrUpdated, bElement)
+				}
+				continue mainLoop
+			}
+		}
+		removed = append(removed, aElement.Key)
+	}
+	for _, bElement := range b {
+		if !ackutil.InStrings(*bElement.Key, visitedIndexes) {
+			addedOrUpdated = append(addedOrUpdated, bElement)
+		}
+	}
+	return addedOrUpdated, removed
+}
+
+// equalTags returns true if two Tag arrays are equal regardless of the order
+// of their elements.
+func EqualTags(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) bool {
+	addedOrUpdated, removed := computeTagsDelta(a, b)
+	return len(addedOrUpdated) == 0 && len(removed) == 0
+}
+
+// svcTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag array.
+func sdkTagsFromResourceTags(rTags []*svcapitypes.Tag) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = &svcsdk.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
+}

--- a/templates/hooks/activity/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/activity/sdk_read_one_post_set_output.go.tpl
@@ -1,0 +1,3 @@
+	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
+		return nil, err
+	}

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -48,8 +48,3 @@ def k8s_client():
 @pytest.fixture(scope='module')
 def sfn_client():
     return boto3.client('stepfunctions')
-
-
-@pytest.fixture(scope='module')
-def s3_resource():
-    return boto3.resource('stepfunctions')

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5220331d003e3a23de4470e68d02c99b16c81989
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@58ffb067d7c400ffbd0d470e975056efdc9e4965

--- a/test/e2e/resources/activity.yaml
+++ b/test/e2e/resources/activity.yaml
@@ -4,3 +4,10 @@ metadata:
   name: $ACTIVITY_NAME
 spec:
   name: $ACTIVITY_NAME
+  tags:
+  - key: k1
+    value: v1
+  - key: k2
+    value: v2
+  - key: k3
+    value: v3

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -29,8 +29,10 @@ def service_bootstrap() -> Resources:
     logging.getLogger().setLevel(logging.INFO)
 
     resources = BootstrapResources(
-        SfnExecutionRole=Role("ack-sfn-execution-role", "states.amazonaws.com",
-                              managed_policies=["arn:aws:iam::aws:policy/AWSDenyAll"]
+        SfnExecutionRole=Role(
+            "ack-sfn-execution-role",
+            "states.amazonaws.com",
+            managed_policies=["arn:aws:iam::aws:policy/AWSDenyAll"],
         )
     )
 

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Helper functions for SFN e2e tests
+"""
+
+import logging
+
+class SFNHelper:
+    def __init__(self, sfn_client):
+        self.sfn_client = sfn_client
+
+    def get_activity(self, activity_arn: str) -> dict:
+        try:
+            resp = self.sfn_client.describe_activity(
+                activityArn=activity_arn
+            )
+            return resp
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+    def get_resource_tags(self, activity_arn: str):
+        resource_tags = self.sfn_client.list_tags_for_resource(
+            resourceArn=activity_arn,
+        )
+        return resource_tags['tags']
+
+    def activity_exists(self, activity_arn) -> bool:
+        return self.get_activity(activity_arn) is not None

--- a/test/e2e/tests/test_activity.py
+++ b/test/e2e/tests/test_activity.py
@@ -17,108 +17,115 @@
 import pytest
 import time
 import logging
-from typing import Generator
-from dataclasses import dataclass
 
+from acktest import tags
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_sfn_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e.tests.helper import SFNHelper
 
 RESOURCE_PLURAL = "activities"
 
 CREATE_WAIT_AFTER_SECONDS = 20
+UPDATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 60
 
+@pytest.fixture
+def basic_activity():
+    resource_name = random_suffix_name("sfn-activity", 24)
 
-@dataclass
-class Activity:
-    ref: k8s.CustomResourceReference
-    resource_name: str
-    resource_data: str
-    arn: str
-
-
-def activity_exists(sfn_client, activity: Activity) -> bool:
-    try:
-        resp = sfn_client.describe_activity(activityArn=activity.arn)
-    except Exception as e:
-        logging.debug(e)
-        return False
-
-    if resp["name"] == activity.resource_name:
-        return True
-
-    return False
-
-
-def load_activity_resource(resource_file_name: str, resource_name: str):
     replacements = REPLACEMENT_VALUES.copy()
     replacements["ACTIVITY_NAME"] = resource_name
 
     resource_data = load_sfn_resource(
-        resource_file_name,
+        "activity",
         additional_replacements=replacements,
     )
     logging.debug(resource_data)
-    return resource_data
 
-
-def create_activity(resource_file_name: str) -> Activity:
-    resource_name = random_suffix_name("sfn-activity", 24)
-    resource_data = load_activity_resource(resource_file_name, resource_name)
-
-    logging.info(f"Creating Activity {resource_name}")
-    # Create k8s resource
+    # Create the k8s resource
     ref = k8s.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
         resource_name, namespace="default",
     )
-    resource_data = k8s.create_custom_resource(ref, resource_data)
-    k8s.wait_resource_consumed_by_controller(ref)
+    k8s.create_custom_resource(ref, resource_data)
 
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-    res = k8s.get_resource(ref)
-    arn = k8s.get_resource_arn(res)
+    # Get latest activity CR
+    cr = k8s.wait_resource_consumed_by_controller(ref)
 
-    return Activity(ref, resource_name, resource_data, arn)
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
 
+    yield (ref, cr)
 
-def delete_activity(activity: Activity):
-    # Delete k8s resource
-    _, deleted = k8s.delete_custom_resource(activity.ref)
-    assert deleted is True
-
-    time.sleep(DELETE_WAIT_AFTER_SECONDS)
-
-@pytest.fixture(scope="function")
-def basic_activity(sfn_client) -> Generator[Activity, None, None]:
-    activity = None
+    # Try to delete, if doesn't already exist
     try:
-        activity = create_activity("activity")
-        assert k8s.get_resource_exists(activity.ref)
-
-        exists = activity_exists(sfn_client, activity)
-        assert exists
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
     except:
-        if activity is not None:
-            delete_activity(activity)
-        return pytest.fail("Activity failed to create")
-
-    yield activity
-
-    exists = activity_exists(sfn_client, activity)
-    if exists:
-        delete_activity(activity)
-
+        pass
 
 @service_marker
 class TestActivity:
-    def test_basic(self, basic_activity, sfn_client):
-        # Existance assertions are handled by the fixture
-        assert basic_activity
+    def test_basic(self, sfn_client, basic_activity):
+        (ref, cr) = basic_activity
 
-        delete_activity(basic_activity)
-        exists = activity_exists(sfn_client, basic_activity)
-        assert not exists
+        activity_arn = cr["status"]["ackResourceMetadata"]["arn"]
+
+        sfn_helper = SFNHelper(sfn_client)
+        # verify that activity exists
+        assert sfn_helper.activity_exists(activity_arn)
+
+        activity_tags = sfn_helper.get_resource_tags(activity_arn)
+        tags.assert_ack_system_tags(
+            tags=activity_tags,
+            key_member_name = 'key',
+            value_member_name  = 'value'
+        )
+        tags.assert_equal_without_ack_tags(
+            actual=cr["spec"]["tags"],
+            expected=activity_tags,
+            key_member_name = 'key',
+            value_member_name  = 'value'
+        )
+
+        # updates tags
+        # deleting k1 and k2, updating k3 value and adding two new tags
+        new_tags = [
+            {
+                "key": "k3",
+                "value": "v3-new",
+            },
+            {
+                "key": "k4",
+                "value": "v4",
+            },
+            {
+                "key": "k5",
+                "value": "v5",
+            }
+        ]
+        cr["spec"]["tags"] = new_tags
+        # Patch k8s resource
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        activity_tags = sfn_helper.get_resource_tags(activity_arn)
+        tags.assert_equal_without_ack_tags(
+            actual=cr["spec"]["tags"],
+            expected=activity_tags,
+            key_member_name = 'key',
+            value_member_name  = 'value'
+        )
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check activity doesn't exist
+        assert not sfn_helper.activity_exists(activity_arn)


### PR DESCRIPTION
This patch adds tags update support for `Activity` resource. In this
same PR the tests are rewritten to follow the same patterns we use to
test other controllers.

By submitting this pull request, I confirm that my contribution is made 
under the terms of the Apache 2.0 license.
