### PR TITLE
Support tag updates for `StateMachine` resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-08-11T00:55:59Z"
+  build_date: "2022-08-16T14:38:22Z"
   build_hash: 87477ae8ca8ac6ddb8c565bbd910cc7e30f55ed0
   go_version: go1.18.1
   version: v0.19.3
@@ -7,7 +7,7 @@ api_directory_checksum: fb0d67de142257cc8f80703c3f14eabbd87711b7
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: acf47eb68cd1d37f15d79905899c2247dfd4a4f8
+  file_checksum: 454d0d8e87016dbb4b53955ac467217940f4f265
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1,9 +1,22 @@
 resources:
   StateMachine:
+    fields:
+      Name:
+        is_immutable: true
+      Tags:
+        compare:
+          is_ignored: True
     exceptions:
       errors:
         404:
           code: StateMachineDoesNotExist
+    hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
+      sdk_read_one_post_set_output:
+        template_path: hooks/statemachine/sdk_read_one_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateStateMachine
   Activity:
     exceptions:
       errors:

--- a/generator.yaml
+++ b/generator.yaml
@@ -1,9 +1,22 @@
 resources:
   StateMachine:
+    fields:
+      Name:
+        is_immutable: true
+      Tags:
+        compare:
+          is_ignored: True
     exceptions:
       errors:
         404:
           code: StateMachineDoesNotExist
+    hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
+      sdk_read_one_post_set_output:
+        template_path: hooks/statemachine/sdk_read_one_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateStateMachine
   Activity:
     exceptions:
       errors:

--- a/pkg/resource/state_machine/delta.go
+++ b/pkg/resource/state_machine/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Definition, b.ko.Spec.Definition) {
 		delta.Add("Spec.Definition", a.ko.Spec.Definition, b.ko.Spec.Definition)
@@ -82,9 +83,6 @@ func newResourceDelta(
 		if *a.ko.Spec.RoleARN != *b.ko.Spec.RoleARN {
 			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
 		}
-	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TracingConfiguration, b.ko.Spec.TracingConfiguration) {
 		delta.Add("Spec.TracingConfiguration", a.ko.Spec.TracingConfiguration, b.ko.Spec.TracingConfiguration)

--- a/pkg/resource/state_machine/hooks.go
+++ b/pkg/resource/state_machine/hooks.go
@@ -1,0 +1,174 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package state_machine
+
+import (
+	"context"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go/service/sfn"
+
+	svcapitypes "github.com/aws-controllers-k8s/sfn-controller/apis/v1alpha1"
+	commonutil "github.com/aws-controllers-k8s/sfn-controller/pkg/util"
+)
+
+// setResourceAdditionalFields queries and adds the tags to a StateMachine resource
+func (rm *resourceManager) setResourceAdditionalFields(
+	ctx context.Context,
+	ko *svcapitypes.StateMachine,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setResourceAdditionalFields")
+	defer exit(err)
+
+	// Set StateMachine tags
+	ko.Spec.Tags, err = commonutil.GetResourceTags(
+		ctx,
+		rm.sdkapi,
+		rm.metrics,
+		string(*ko.Status.ACKResourceMetadata.ARN),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// customUpdateStateMachine patches each of the resource properties in the backend AWS
+// service API and returns a new resource with updated fields.
+func (rm *resourceManager) customUpdateStateMachine(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (*resource, error) {
+	if delta.DifferentAt("Spec.Tags") {
+		err := commonutil.SyncResourceTags(
+			ctx,
+			rm.sdkapi,
+			rm.metrics,
+			string(*desired.ko.Status.ACKResourceMetadata.ARN),
+			latest.ko.Spec.Tags,
+			desired.ko.Spec.Tags,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if delta.DifferentExcept("Spec.Tags") {
+		err := rm.updateStateMachine(ctx, desired)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return desired, nil
+}
+
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		if !commonutil.EqualTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
+// sdkUpdate patches the supplied resource in the backend AWS service API and
+// returns a new resource with updated fields.
+func (rm *resourceManager) updateStateMachine(
+	ctx context.Context,
+	desired *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkUpdate")
+	defer func() {
+		exit(err)
+	}()
+	input, err := rm.newUpdateRequestPayload(ctx, desired)
+	if err != nil {
+		return err
+	}
+
+	_, err = rm.sdkapi.UpdateStateMachineWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateStateMachine", err)
+	if err != nil {
+		return err
+	}
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := desired.ko.DeepCopy()
+
+	rm.setStatusDefaults(ko)
+	return nil
+}
+
+// newUpdateRequestPayload returns an SDK-specific struct for the HTTP request
+// payload of the Update API call for the resource
+func (rm *resourceManager) newUpdateRequestPayload(
+	ctx context.Context,
+	r *resource,
+) (*svcsdk.UpdateStateMachineInput, error) {
+	res := &svcsdk.UpdateStateMachineInput{}
+
+	if r.ko.Spec.Definition != nil {
+		res.SetDefinition(*r.ko.Spec.Definition)
+	}
+	if r.ko.Spec.LoggingConfiguration != nil {
+		f1 := &svcsdk.LoggingConfiguration{}
+		if r.ko.Spec.LoggingConfiguration.Destinations != nil {
+			f1f0 := []*svcsdk.LogDestination{}
+			for _, f1f0iter := range r.ko.Spec.LoggingConfiguration.Destinations {
+				f1f0elem := &svcsdk.LogDestination{}
+				if f1f0iter.CloudWatchLogsLogGroup != nil {
+					f1f0elemf0 := &svcsdk.CloudWatchLogsLogGroup{}
+					if f1f0iter.CloudWatchLogsLogGroup.LogGroupARN != nil {
+						f1f0elemf0.SetLogGroupArn(*f1f0iter.CloudWatchLogsLogGroup.LogGroupARN)
+					}
+					f1f0elem.SetCloudWatchLogsLogGroup(f1f0elemf0)
+				}
+				f1f0 = append(f1f0, f1f0elem)
+			}
+			f1.SetDestinations(f1f0)
+		}
+		if r.ko.Spec.LoggingConfiguration.IncludeExecutionData != nil {
+			f1.SetIncludeExecutionData(*r.ko.Spec.LoggingConfiguration.IncludeExecutionData)
+		}
+		if r.ko.Spec.LoggingConfiguration.Level != nil {
+			f1.SetLevel(*r.ko.Spec.LoggingConfiguration.Level)
+		}
+		res.SetLoggingConfiguration(f1)
+	}
+	if r.ko.Spec.RoleARN != nil {
+		res.SetRoleArn(*r.ko.Spec.RoleARN)
+	}
+	if r.ko.Status.ACKResourceMetadata != nil && r.ko.Status.ACKResourceMetadata.ARN != nil {
+		res.SetStateMachineArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
+	}
+	if r.ko.Spec.TracingConfiguration != nil {
+		f4 := &svcsdk.TracingConfiguration{}
+		if r.ko.Spec.TracingConfiguration.Enabled != nil {
+			f4.SetEnabled(*r.ko.Spec.TracingConfiguration.Enabled)
+		}
+		res.SetTracingConfiguration(f4)
+	}
+
+	return res, nil
+}

--- a/templates/hooks/statemachine/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/statemachine/sdk_read_one_post_set_output.go.tpl
@@ -1,0 +1,3 @@
+	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
+		return nil, err
+	}

--- a/test/e2e/resources/state_machine.yaml
+++ b/test/e2e/resources/state_machine.yaml
@@ -6,3 +6,10 @@ spec:
   name: $STATE_MACHINE_NAME
   roleARN: $SFN_EXECUTION_ROLE_ARN
   definition: "{ \"StartAt\": \"HelloWorld\", \"States\": { \"HelloWorld\": { \"Type\": \"Pass\", \"Result\": \"Hello World!\", \"End\": true }}}"
+  tags:
+  - key: k1
+    value: v1
+  - key: k2
+    value: v2
+  - key: k3
+    value: v3

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -39,3 +39,17 @@ class SFNHelper:
 
     def activity_exists(self, activity_arn) -> bool:
         return self.get_activity(activity_arn) is not None
+
+    def get_state_machine(self, state_machine_arn: str) -> dict:
+        try:
+            resp = self.sfn_client.describe_state_machine(
+                stateMachineArn=state_machine_arn
+            )
+            return resp
+
+        except Exception as e:
+            logging.debug(e)
+            return None
+
+    def state_machine_exists(self, state_machine_arn) -> bool:
+        return self.get_state_machine(state_machine_arn) is not None

--- a/test/e2e/tests/test_state_machine.py
+++ b/test/e2e/tests/test_state_machine.py
@@ -17,109 +17,125 @@
 import pytest
 import time
 import logging
-from typing import Generator
-from dataclasses import dataclass
 
+from acktest import tags
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_sfn_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e.tests.helper import SFNHelper
+from e2e.bootstrap_resources import get_bootstrap_resources
 
 RESOURCE_PLURAL = "statemachines"
 
 CREATE_WAIT_AFTER_SECONDS = 20
+UPDATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 60
 
+@pytest.fixture
+def basic_state_machine():
+    resource_name = random_suffix_name("sfn-statemachine", 24)
 
-@dataclass
-class StateMachine:
-    ref: k8s.CustomResourceReference
-    resource_name: str
-    resource_data: str
-    arn: str
-
-
-def state_machine_exists(sfn_client, state_machine: StateMachine) -> bool:
-    try:
-        resp = sfn_client.describe_state_machine(stateMachineArn=state_machine.arn)
-    except Exception as e:
-        logging.debug(e)
-        return False
-
-    if resp["name"] == state_machine.resource_name:
-        return True
-
-    return False
-
-
-def load_state_machine_resource(resource_file_name: str, resource_name: str):
     replacements = REPLACEMENT_VALUES.copy()
     replacements["STATE_MACHINE_NAME"] = resource_name
+    replacements["SFN_EXECUTION_ROLE_ARN"] = get_bootstrap_resources().SfnExecutionRole.arn
 
     resource_data = load_sfn_resource(
-        resource_file_name,
+        "state_machine",
         additional_replacements=replacements,
     )
     logging.debug(resource_data)
-    return resource_data
 
-
-def create_state_machine(resource_file_name: str) -> StateMachine:
-    resource_name = random_suffix_name("sfn-state-machine", 24)
-    resource_data = load_state_machine_resource(resource_file_name, resource_name)
-
-    logging.info(f"Creating StateMachine {resource_name}")
-    # Create k8s resource
+    # Create the k8s resource
     ref = k8s.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
         resource_name, namespace="default",
     )
-    resource_data = k8s.create_custom_resource(ref, resource_data)
-    k8s.wait_resource_consumed_by_controller(ref)
+    k8s.create_custom_resource(ref, resource_data)
 
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-    res = k8s.get_resource(ref)
-    arn = k8s.get_resource_arn(res)
+    # Get latest state machine CR
+    cr = k8s.wait_resource_consumed_by_controller(ref)
 
-    return StateMachine(ref, resource_name, resource_data, arn)
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
 
+    yield (ref, cr)
 
-def delete_state_machine(state_machine: StateMachine):
-    # Delete k8s resource
-    _, deleted = k8s.delete_custom_resource(state_machine.ref)
-    assert deleted is True
-
-    time.sleep(DELETE_WAIT_AFTER_SECONDS)
-
-
-@pytest.fixture(scope="function")
-def basic_state_machine(sfn_client) -> Generator[StateMachine, None, None]:
-    state_machine = None
+    # Try to delete, if doesn't already exist
     try:
-        state_machine = create_state_machine("state_machine")
-        assert k8s.get_resource_exists(state_machine.ref)
-
-        exists = state_machine_exists(sfn_client, state_machine)
-        assert exists
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
     except:
-        if state_machine is not None:
-            delete_state_machine(state_machine)
-        return pytest.fail("StateMachine failed to create")
-
-    yield state_machine
-
-    exists = state_machine_exists(sfn_client, state_machine)
-    if exists:
-        delete_state_machine(state_machine)
-
+        pass
 
 @service_marker
 class TestStateMachine:
-    def test_basic(self, basic_state_machine, sfn_client):
-        # Existance assertions are handled by the fixture
-        assert basic_state_machine
+    def test_basic(self, sfn_client, basic_state_machine):
+        (ref, cr) = basic_state_machine
 
-        delete_state_machine(basic_state_machine)
-        exists = state_machine_exists(sfn_client, basic_state_machine)
-        assert not exists
+        state_machine_arn = cr["status"]["ackResourceMetadata"]["arn"]
+
+        sfn_helper = SFNHelper(sfn_client)
+        # verify that state machine exists
+        assert sfn_helper.state_machine_exists(state_machine_arn)
+
+        state_machine_tags = sfn_helper.get_resource_tags(state_machine_arn)
+        tags.assert_ack_system_tags(
+            tags=state_machine_tags,
+            key_member_name = 'key',
+            value_member_name  = 'value'
+        )
+        tags.assert_equal_without_ack_tags(
+            actual=cr["spec"]["tags"],
+            expected=state_machine_tags,
+            key_member_name = 'key',
+            value_member_name  = 'value'
+        )
+
+        # updates tags
+        # deleting k1 and k2, updating k3 value and adding two new tags
+        new_tags = [
+            {
+                "key": "k3",
+                "value": "v3-new",
+            },
+            {
+                "key": "k4",
+                "value": "v4",
+            },
+            {
+                "key": "k5",
+                "value": "v5",
+            }
+        ]
+        cr["spec"]["tags"] = new_tags
+        # update tracing configuration
+        cr["spec"]["tracingConfiguration"] = {
+            "enabled": True,
+        }
+
+        # Patch k8s resource
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        state_machine_tags = sfn_helper.get_resource_tags(state_machine_arn)
+        tags.assert_equal_without_ack_tags(
+            actual=cr["spec"]["tags"],
+            expected=state_machine_tags,
+            key_member_name = 'key',
+            value_member_name  = 'value'
+        )
+
+        state_machine = sfn_helper.get_state_machine(cr["status"]["ackResourceMetadata"]["arn"])
+        assert state_machine["tracingConfiguration"]["enabled"]
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check state machine doesn't exist
+        assert not sfn_helper.state_machine_exists(state_machine_arn)


### PR DESCRIPTION
This patch adds tags update support for `StateMachine` resource.
In this same PR the tests are rewritten to follow the same patterns
we use to test other controllers.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
