### PR TITLE
Mark StateMachine.Definition as is_document

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-12T18:02:30Z"
+  build_date: "2026-06-19T03:10:51Z"
   build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
-  go_version: go1.26.3
+  go_version: go1.26.0
   version: v0.59.1-7-g2970ca9
 api_directory_checksum: eb989a0b073ba8beb1724c8b766541eafd88adce
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: e4a246184c6d55757223f2e59053d3fc142e8c98
+  file_checksum: bf952c66c3d138cbb49d710cd7fdbea994f1d05f
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -10,6 +10,8 @@ ignore:
 resources:
   StateMachine:
     fields:
+      Definition:
+        is_document: true
       Name:
         is_immutable: true
       Tags:

--- a/generator.yaml
+++ b/generator.yaml
@@ -10,6 +10,8 @@ ignore:
 resources:
   StateMachine:
     fields:
+      Definition:
+        is_document: true
       Name:
         is_immutable: true
       Tags:

--- a/pkg/resource/state_machine/delta.go
+++ b/pkg/resource/state_machine/delta.go
@@ -46,7 +46,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.Definition, b.ko.Spec.Definition) {
 		delta.Add("Spec.Definition", a.ko.Spec.Definition, b.ko.Spec.Definition)
 	} else if a.ko.Spec.Definition != nil && b.ko.Spec.Definition != nil {
-		if *a.ko.Spec.Definition != *b.ko.Spec.Definition {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.Definition, *b.ko.Spec.Definition); err != nil || !equal {
 			delta.Add("Spec.Definition", a.ko.Spec.Definition, b.ko.Spec.Definition)
 		}
 	}

--- a/test/e2e/tests/test_state_machine.py
+++ b/test/e2e/tests/test_state_machine.py
@@ -131,6 +131,15 @@ class TestStateMachine:
         state_machine = sfn_helper.get_state_machine(cr["status"]["ackResourceMetadata"]["arn"])
         assert state_machine["tracingConfiguration"]["enabled"]
 
+        # Update definition to verify is_document comparison works
+        new_definition = '{"StartAt":"HelloWorld","States":{"HelloWorld":{"Type":"Pass","Result":"Updated!","End":true}}}'
+        updates = {
+            "spec": {"definition": new_definition},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted is True


### PR DESCRIPTION
## Summary

Adds is_document: true annotation to StateMachine.Definition field in generator.yaml.

## Problem

The StateMachine.Definition field accepts an Amazon States Language JSON document. Without the is_document annotation, the controller uses strict string comparison which causes false drift detection and infinite reconciliation loops when the API returns reformatted (but semantically equivalent) JSON.

## Changes

- Added is_document: true to StateMachine.Definition in generator.yaml
- Regenerated controller code - delta.go now uses DocumentEqual for semantic comparison

## Testing

- go build ./cmd/controller - compiles cleanly
- Existing e2e test (state_machine.yaml fixture) already exercises the definition field with JSON content

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.