### PR TITLE
Add IAM Role reference to StateMachine.roleARN

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -20,6 +20,7 @@ include an indication of the Open Source License under which that package is
 distributed. For any package *NOT* distributed under the terms of the Apache
 License version 2.0, we include the full text of the package's License below.
 
+* `github.com/aws-controllers-k8s/iam-controller`
 * `github.com/aws-controllers-k8s/runtime`
 * `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
@@ -32,34 +33,26 @@ License version 2.0, we include the full text of the package's License below.
 * `k8s.io/client-go`
 * `sigs.k8s.io/controller-runtime`
 
-### github.com/aws-controllers-k8s/runtime
+### github.com/aws-controllers-k8s/iam-controller
 
 License Identifier: Apache-2.0
 
 Subdependencies:
+* `github.com/aws-controllers-k8s/runtime`
+* `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
-* `github.com/aws/aws-sdk-go-v2/config`
-* `github.com/aws/aws-sdk-go-v2/credentials`
-* `github.com/aws/aws-sdk-go-v2/service/sts`
+* `github.com/aws/aws-sdk-go-v2/service/iam`
 * `github.com/aws/smithy-go`
-* `github.com/cenkalti/backoff/v4`
 * `github.com/go-logr/logr`
-* `github.com/go-logr/zapr`
-* `github.com/google/go-cmp`
-* `github.com/itchyny/gojq`
-* `github.com/jaypipes/envutil`
-* `github.com/micahhausler/aws-iam-policy`
-* `github.com/pkg/errors`
-* `github.com/prometheus/client_golang`
+* `github.com/samber/lo`
 * `github.com/spf13/pflag`
 * `github.com/stretchr/testify`
-* `go.uber.org/zap`
 * `k8s.io/api`
 * `k8s.io/apimachinery`
 * `k8s.io/client-go`
-* `k8s.io/klog/v2`
-* `k8s.io/utils`
 * `sigs.k8s.io/controller-runtime`
+* `github.com/aws/aws-sdk-go-v2/config`
+* `github.com/aws/aws-sdk-go-v2/credentials`
 * `github.com/aws/aws-sdk-go-v2/feature/ec2/imds`
 * `github.com/aws/aws-sdk-go-v2/internal/configsources`
 * `github.com/aws/aws-sdk-go-v2/internal/endpoints/v2`
@@ -68,36 +61,46 @@ Subdependencies:
 * `github.com/aws/aws-sdk-go-v2/service/internal/presigned-url`
 * `github.com/aws/aws-sdk-go-v2/service/sso`
 * `github.com/aws/aws-sdk-go-v2/service/ssooidc`
+* `github.com/aws/aws-sdk-go-v2/service/sts`
 * `github.com/beorn7/perks`
+* `github.com/cenkalti/backoff/v4`
 * `github.com/cespare/xxhash/v2`
 * `github.com/davecgh/go-spew`
 * `github.com/emicklei/go-restful/v3`
-* `github.com/evanphx/json-patch`
 * `github.com/evanphx/json-patch/v5`
 * `github.com/fsnotify/fsnotify`
 * `github.com/fxamacker/cbor/v2`
+* `github.com/go-logr/zapr`
 * `github.com/go-openapi/jsonpointer`
 * `github.com/go-openapi/jsonreference`
 * `github.com/go-openapi/swag`
 * `github.com/google/btree`
 * `github.com/google/gnostic-models`
+* `github.com/google/go-cmp`
 * `github.com/google/uuid`
+* `github.com/itchyny/gojq`
 * `github.com/itchyny/timefmt-go`
+* `github.com/jaypipes/envutil`
+* `github.com/jmespath/go-jmespath`
 * `github.com/josharian/intern`
 * `github.com/json-iterator/go`
 * `github.com/mailru/easyjson`
+* `github.com/micahhausler/aws-iam-policy`
 * `github.com/modern-go/concurrent`
 * `github.com/modern-go/reflect2`
 * `github.com/munnerz/goautoneg`
+* `github.com/pkg/errors`
 * `github.com/pmezard/go-difflib`
+* `github.com/prometheus/client_golang`
 * `github.com/prometheus/client_model`
 * `github.com/prometheus/common`
 * `github.com/prometheus/procfs`
-* `github.com/stretchr/objx`
 * `github.com/x448/float16`
 * `go.uber.org/multierr`
+* `go.uber.org/zap`
 * `go.yaml.in/yaml/v2`
 * `go.yaml.in/yaml/v3`
+* `golang.org/x/exp`
 * `golang.org/x/net`
 * `golang.org/x/oauth2`
 * `golang.org/x/sync`
@@ -111,25 +114,27 @@ Subdependencies:
 * `gopkg.in/inf.v0`
 * `gopkg.in/yaml.v3`
 * `k8s.io/apiextensions-apiserver`
+* `k8s.io/klog/v2`
 * `k8s.io/kube-openapi`
+* `k8s.io/utils`
 * `sigs.k8s.io/json`
 * `sigs.k8s.io/randfill`
 * `sigs.k8s.io/structured-merge-diff/v6`
 * `sigs.k8s.io/yaml`
 
+#### github.com/aws-controllers-k8s/runtime
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go
+
+License Identifier: Apache-2.0
+
 #### github.com/aws/aws-sdk-go-v2
 
 License Identifier: Apache-2.0
 
-#### github.com/aws/aws-sdk-go-v2/config
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/credentials
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/service/sts
+#### github.com/aws/aws-sdk-go-v2/service/iam
 
 License Identifier: Apache-2.0
 
@@ -137,78 +142,17 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-#### github.com/cenkalti/backoff/v4
-
-License Identifier: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2014 Cenk Altı
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 #### github.com/go-logr/logr
 
 License Identifier: Apache-2.0
 
-#### github.com/go-logr/zapr
-
-License Identifier: Apache-2.0
-
-#### github.com/google/go-cmp
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2017 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### github.com/itchyny/gojq
+#### github.com/samber/lo
 
 License Identifier: MIT
 
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2019-2021 itchyny
+Copyright (c) 2022 Samuel Berthe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -227,56 +171,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-#### github.com/jaypipes/envutil
-
-License Identifier: Apache-2.0
-
-#### github.com/micahhausler/aws-iam-policy
-
-License Identifier: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2023, Micah Hausler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-#### github.com/pkg/errors
-
-License Identifier: BSD-2-Clause
-
-Copyright (c) 2015, Dave Cheney <dave@cheney.net>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### github.com/prometheus/client_golang
-
-License Identifier: Apache-2.0
 
 #### github.com/spf13/pflag
 
@@ -337,28 +231,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-#### go.uber.org/zap
-
-Copyright (c) 2016-2017 Uber Technologies, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
 #### k8s.io/api
 
 License Identifier: Apache-2.0
@@ -371,15 +243,15 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-#### k8s.io/klog/v2
-
-License Identifier: Apache-2.0
-
-#### k8s.io/utils
-
-License Identifier: Apache-2.0
-
 #### sigs.k8s.io/controller-runtime
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/config
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/credentials
 
 License Identifier: Apache-2.0
 
@@ -415,6 +287,10 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
+#### github.com/aws/aws-sdk-go-v2/service/sts
+
+License Identifier: Apache-2.0
+
 #### github.com/beorn7/perks
 
 Copyright (C) 2013 Blake Mizerany
@@ -437,6 +313,31 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#### github.com/cenkalti/backoff/v4
+
+License Identifier: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #### github.com/cespare/xxhash/v2
 
@@ -511,36 +412,6 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-#### github.com/evanphx/json-patch
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### github.com/evanphx/json-patch/v5
 
@@ -628,6 +499,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+#### github.com/go-logr/zapr
+
+License Identifier: Apache-2.0
+
 #### github.com/go-openapi/jsonpointer
 
 License Identifier: Apache-2.0
@@ -647,6 +522,38 @@ License Identifier: Apache-2.0
 #### github.com/google/gnostic-models
 
 License Identifier: Apache-2.0
+
+#### github.com/google/go-cmp
+
+License Identifier: BSD-3-Clause
+
+Copyright (c) 2017 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### github.com/google/uuid
 
@@ -680,6 +587,32 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#### github.com/itchyny/gojq
+
+License Identifier: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2019-2021 itchyny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 #### github.com/itchyny/timefmt-go
 
 License Identifier: MIT
@@ -705,6 +638,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+#### github.com/jaypipes/envutil
+
+License Identifier: Apache-2.0
+
+#### github.com/jmespath/go-jmespath
+
+License Identifier: Apache-2.0
 
 #### github.com/josharian/intern
 
@@ -768,6 +709,20 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#### github.com/micahhausler/aws-iam-policy
+
+License Identifier: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2023, Micah Hausler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #### github.com/modern-go/concurrent
 
 License Identifier: Apache-2.0
@@ -812,6 +767,34 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#### github.com/pkg/errors
+
+License Identifier: BSD-2-Clause
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #### github.com/pmezard/go-difflib
 
 License Identifier: BSD-3-Clause
@@ -844,6 +827,10 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#### github.com/prometheus/client_golang
+
+License Identifier: Apache-2.0
+
 #### github.com/prometheus/client_model
 
 License Identifier: Apache-2.0
@@ -855,33 +842,6 @@ License Identifier: Apache-2.0
 #### github.com/prometheus/procfs
 
 License Identifier: Apache-2.0
-
-#### github.com/stretchr/objx
-
-License Identifier: MIT
-
-The MIT License
-
-Copyright (c) 2014 Stretchr, Inc.
-Copyright (c) 2017-2018 objx contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 #### github.com/x448/float16
 
@@ -931,6 +891,28 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+#### go.uber.org/zap
+
+Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 #### go.yaml.in/yaml/v2
 
 License Identifier: Apache-2.0
@@ -938,6 +920,38 @@ License Identifier: Apache-2.0
 #### go.yaml.in/yaml/v3
 
 License Identifier: Apache-2.0
+
+#### golang.org/x/exp
+
+License Identifier: BSD-3-Clause
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### golang.org/x/net
 
@@ -1270,7 +1284,15 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
+#### k8s.io/klog/v2
+
+License Identifier: Apache-2.0
+
 #### k8s.io/kube-openapi
+
+License Identifier: Apache-2.0
+
+#### k8s.io/utils
 
 License Identifier: Apache-2.0
 
@@ -1529,26 +1551,11 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-### github.com/aws/aws-sdk-go
 
-License Identifier: Apache-2.0
 
-Subdependencies:
-* `github.com/jmespath/go-jmespath`
-* `golang.org/x/net`
-* `golang.org/x/text`
 
-#### github.com/jmespath/go-jmespath
 
-License Identifier: Apache-2.0
 
-### github.com/aws/aws-sdk-go-v2
-
-License Identifier: Apache-2.0
-
-Subdependencies:
-* `github.com/aws/smithy-go`
-* `github.com/jmespath/go-jmespath`
 
 ### github.com/aws/aws-sdk-go-v2/service/sfn
 

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:04:37Z"
+  build_date: "2026-06-23T17:50:07Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
+  go_version: go1.26.0
   version: v0.60.0
-api_directory_checksum: eb989a0b073ba8beb1724c8b766541eafd88adce
+api_directory_checksum: 747b8972613cada8a780d3d56a59ab89cb51d0e0
 api_version: v1alpha1
-aws_sdk_go_version: v1.32.6
+aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: bf952c66c3d138cbb49d710cd7fdbea994f1d05f
+  file_checksum: f3809742cdeb56d69ba0edc62c1ac4a76bbc976a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -14,6 +14,11 @@ resources:
         is_document: true
       Name:
         is_immutable: true
+      RoleARN:
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       Tags:
         compare:
           is_ignored: True

--- a/apis/v1alpha1/state_machine.go
+++ b/apis/v1alpha1/state_machine.go
@@ -43,8 +43,8 @@ type StateMachineSpec struct {
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
 	// The Amazon Resource Name (ARN) of the IAM role to use for this state machine.
-	// +kubebuilder:validation:Required
-	RoleARN *string `json:"roleARN"`
+	RoleARN *string                                  `json:"roleARN,omitempty"`
+	RoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"roleRef,omitempty"`
 	// Tags to be added when creating a state machine.
 	//
 	// An array of key-value pairs. For more information, see Using Cost Allocation

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -863,6 +863,11 @@ func (in *StateMachineSpec) DeepCopyInto(out *StateMachineSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RoleRef != nil {
+		in, out := &in.RoleRef, &out.RoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]*Tag, len(*in))

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"os"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -58,6 +59,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = iamapitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/sfn.services.k8s.aws_statemachines.yaml
+++ b/config/crd/bases/sfn.services.k8s.aws_statemachines.yaml
@@ -82,6 +82,23 @@ spec:
                 description: The Amazon Resource Name (ARN) of the IAM role to use
                   for this state machine.
                 type: string
+              roleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: |-
                   Tags to be added when creating a state machine.
@@ -127,7 +144,6 @@ spec:
             required:
             - definition
             - name
-            - roleARN
             type: object
           status:
             description: StateMachineStatus defines the observed state of StateMachine

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -23,6 +23,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - services.k8s.aws
   resources:
   - fieldexports

--- a/generator.yaml
+++ b/generator.yaml
@@ -14,6 +14,11 @@ resources:
         is_document: true
       Name:
         is_immutable: true
+      RoleARN:
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       Tags:
         compare:
           is_ignored: True

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws-controllers-k8s/sfn-controller
 go 1.25.0
 
 require (
+	github.com/aws-controllers-k8s/iam-controller v1.7.2
 	github.com/aws-controllers-k8s/runtime v0.60.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/aws-controllers-k8s/iam-controller v1.7.2 h1:voWlgUA8yDTQTGkdKslMydNyY4mXAH8TaRtW4216g0U=
+github.com/aws-controllers-k8s/iam-controller v1.7.2/go.mod h1:GW/KAJdhJ97rhFVJq/8c2iVT4mrA8zi8T4Eu+zhUrqM=
 github.com/aws-controllers-k8s/runtime v0.60.0 h1:obCtliXzv+HqpVwEHZ388wC7uBDVdGWeuK8DMHcPcIE=
 github.com/aws-controllers-k8s/runtime v0.60.0/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=

--- a/helm/crds/sfn.services.k8s.aws_statemachines.yaml
+++ b/helm/crds/sfn.services.k8s.aws_statemachines.yaml
@@ -82,6 +82,23 @@ spec:
                 description: The Amazon Resource Name (ARN) of the IAM role to use
                   for this state machine.
                 type: string
+              roleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: |-
                   Tags to be added when creating a state machine.
@@ -127,7 +144,6 @@ spec:
             required:
             - definition
             - name
-            - roleARN
             type: object
           status:
             description: StateMachineStatus defines the observed state of StateMachine

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -70,6 +70,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - services.k8s.aws
   resources:
   - fieldexports

--- a/pkg/resource/state_machine/delta.go
+++ b/pkg/resource/state_machine/delta.go
@@ -89,6 +89,9 @@ func newResourceDelta(
 			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.RoleRef, b.ko.Spec.RoleRef) {
+		delta.Add("Spec.RoleRef", a.ko.Spec.RoleRef, b.ko.Spec.RoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TracingConfiguration, b.ko.Spec.TracingConfiguration) {
 		delta.Add("Spec.TracingConfiguration", a.ko.Spec.TracingConfiguration, b.ko.Spec.TracingConfiguration)
 	} else if a.ko.Spec.TracingConfiguration != nil && b.ko.Spec.TracingConfiguration != nil {

--- a/pkg/resource/state_machine/references.go
+++ b/pkg/resource/state_machine/references.go
@@ -17,13 +17,23 @@ package state_machine
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/sfn-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -31,6 +41,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.RoleRef != nil {
+		ko.Spec.RoleARN = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +61,119 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.StateMachine) error {
+
+	if ko.Spec.RoleRef != nil && ko.Spec.RoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("RoleARN", "RoleRef")
+	}
+	if ko.Spec.RoleRef == nil && ko.Spec.RoleARN == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("RoleARN", "RoleRef")
+	}
+	return nil
+}
+
+// resolveReferenceForRoleARN reads the resource referenced
+// from RoleRef field and sets the RoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.StateMachine,
+) (hasReferences bool, err error) {
+	if ko.Spec.RoleRef != nil && ko.Spec.RoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.RoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: RoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.RoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
 	return nil
 }


### PR DESCRIPTION
Description of changes:
Adds a cross-resource reference from `StateMachine.roleARN` to the ACK `iam/Role` resource, allowing the execution role to be resolved from an IAM Role CR via `roleRef`.

Note: `StateMachineAlias.routingConfiguration.stateMachineVersionARN` was flagged by the scanner but skipped — there is no ACK `StateMachineVersion` resource.

Generated with code-generator `v0.60.0` / runtime `v0.60.0`, `AWS_SDK_GO_VERSION=v1.34.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
